### PR TITLE
Update path to spin-runtime-class.yaml

### DIFF
--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -49,7 +49,7 @@ you'll need to modify the RuntimeClass with a `nodeSelector:`.
 <!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
 
 ```console
-kubectl apply -f spin-runtime-class.yaml
+kubectl apply -f config/samples/spin-runtime-class.yaml
 ```
 
 ## Chart prerequisites
@@ -128,7 +128,7 @@ kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0
 
 ```console
 make uninstall
-kubectl delete -f spin-runtime-class.yaml
+kubectl delete -f config/samples/spin-runtime-class.yaml
 ```
 
 <!-- TODO: list out configuration options? -->

--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -53,14 +53,14 @@ k3d cluster create wasm-cluster \
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.yaml
 ```
 
-3. Apply the [Runtime Class](https://github.com/spinkube/spin-operator/blob/main/spin-runtime-class.yaml) used for scheduling Spin apps onto nodes running the shim:
+3. Apply the [Runtime Class](https://github.com/spinkube/spin-operator/blob/main/config/samples/spin-runtime-class.yaml) used for scheduling Spin apps onto nodes running the shim:
 
 > Note: In a production cluster you likely want to customize the runtimeClass with a `nodeSelector:` that matches nodes that have the shim installed. In the K3D example they're installed on every node. 
 
 <!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
 
 ```console
-kubectl apply -f spin-runtime-class.yaml
+kubectl apply -f config/samples/spin-runtime-class.yaml
 ```
 
 4. Apply the [Custom Resource Definitions](../../glossary#custom-resource-definition-crd) used by the Spin Operator:

--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -80,7 +80,7 @@ First, the [Custom Resource Definition (CRD)]({{< ref "/docs/glossary/_index.md#
 make install
 
 # Install the RuntimeClass
-kubectl apply -f spin-runtime-class.yaml
+kubectl apply -f config/samples/spin-runtime-class.yaml
 ```
 
 The following installs [Cert Manager](https://github.com/cert-manager/cert-manager) which is required to automatically provision and manage TLS certificates (used by spin-operator's admission webhook system)

--- a/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
@@ -42,7 +42,7 @@ k3d cluster create wasm-cluster-scale --image ghcr.io/deislabs/containerd-wasm-s
 Next, from within the `spin-operator` directory, run the following commands to install the Spin runtime class and Spin Operator:
 
 ```console
-kubectl apply -f spin-runtime-class.yaml
+kubectl apply -f config/samples/spin-runtime-class.yaml
 make install
 ```
 

--- a/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
@@ -47,7 +47,7 @@ k3d cluster create wasm-cluster-scale --image ghcr.io/deislabs/containerd-wasm-s
 Next, from within the `spin-operator` directory, run the following commands to install the Spin runtime class and Spin Operator:
 
 ```console
-kubectl apply -f spin-runtime-class.yaml
+kubectl apply -f config/samples/spin-runtime-class.yaml
 make install
 ```
 

--- a/content/en/docs/spin-operator/tutorials/spin-operator-development.md
+++ b/content/en/docs/spin-operator/tutorials/spin-operator-development.md
@@ -22,7 +22,7 @@ Make sure you have the proper permission to the registry if the above commands d
 **Apply the Runtime Class to the cluster:**
 
 ```console
-kubectl apply -f spin-runtime-class.yaml
+kubectl apply -f config/samples/spin-runtime-class.yaml
 ```
 
 **Install the CRDs into the cluster:**
@@ -74,7 +74,7 @@ make uninstall
 **Delete the Runtime Class from the cluster:**
 
 ```console
-kubectl delete -f spin-runtime-class.yaml
+kubectl delete -f config/samples/spin-runtime-class.yaml
 ```
 
 **UnDeploy the controller from the cluster:**
@@ -109,7 +109,7 @@ make helm-generate
 
 **Install the Helm chart onto the cluster:**
 
-> **Note**: [CRDs](./config/crd/bases/) and the [wasm-spin-v2](./spin-runtime-class.yaml)
+> **Note**: [CRDs](./config/crd/bases/) and the [wasm-spin-v2](./config/samples/spin-runtime-class.yaml)
 > RuntimeClass are currently _not_ installed as part of the chart. You'll need to ensure these are
 > present via the method(s) mentioned above.
 


### PR DESCRIPTION
The `spin-runtime-class.yaml` has been moved from `./spin-runtime-class.yaml` to `./config/samples/spin-runtime-class.yaml`, this commit reflects this change