### PR TITLE
Quickstart: Use `spin-shim-executor.yaml` instead of `shim-executor.yaml`

### DIFF
--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -84,7 +84,7 @@ make deploy IMG=ghcr.io/spinkube/spin-operator:dev
 Lastly, create the shim executor:
 
 ```console
-kubectl apply -f config/samples/shim-executor.yaml
+kubectl apply -f config/samples/spin-shim-executor.yaml
 ```
 
 ## Run the Sample Application


### PR DESCRIPTION
The corresponding file has been renamed in spin-operator