### PR TITLE
Install cert-manager via Helm chart and use proper naming for cert-manager

### DIFF
--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -54,10 +54,22 @@ kubectl apply -f config/samples/spin-runtime-class.yaml
 
 ## Chart prerequisites
 
-- [Cert Manager](https://github.com/cert-manager/cert-manager) to automatically provision and manage TLS certificates (used by spin-operator's admission webhook system). For detailed installation instructions see [the cert-manager documentation](https://cert-manager.io/docs/installation/).
+- [cert-manager](https://github.com/cert-manager/cert-manager) to automatically provision and manage TLS certificates (used by spin-operator's admission webhook system). For detailed installation instructions see [the cert-manager documentation](https://cert-manager.io/docs/installation/).
 
-```console
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
+```shell
+# Install cert-manager CRDs
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.crds.yaml
+
+# Add and update Jetstack repository
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+
+# Install the cert-manager Helm chart
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.14.3
 ```
 
 ## Chart dependencies


### PR DESCRIPTION
This commit changes the cert-manager installation instructions to use the Helm chart instead of plain k8s manifests as this is part of the "Installing with Helm" tutorial.