### PR TITLE
ci(deploy): build site with custom domain

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  CANONICAL_DOMAIN: www.spinkube.dev
+
 jobs:
   # TODO: place into separate build.yaml (and add PR support?) and then call here?
   build:
@@ -44,7 +47,7 @@ jobs:
           hugo \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+            --baseURL "https://${{ env.CANONICAL_DOMAIN }}/"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
`www.spinkube.dev` is configured as the custom domain for the GH pages website.  Along with the A records added to our registrar, GitHub handles redirects from `spinkube.dev` -> `www.spinkube.dev`.

This updates the base url to use https://www.spinkube.dev.  Not sure if it would also work to just not set any base url, but thought I'd follow the provided pattern.