### PR TITLE
Adjust social media links

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -179,36 +179,36 @@ enable = false
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-  name = "User mailing list"
-  url = "https://example.org/mail"
+  name = "Email"
+  url = "mailto:spinkubemaintainers@gmail.com"
   icon = "fa fa-envelope"
-  desc = "Discussion and help from your fellow users"
+  desc = "SpinKube Maintainers email."
 [[params.links.user]]
-  name ="Twitter"
-  url = "https://example.org/twitter"
-  icon = "fab fa-twitter"
-  desc = "Follow us on Twitter to get the latest Spin framework news!"
-[[params.links.user]]
-  name = "Stack Overflow"
-  url = "https://example.org/stack"
-  icon = "fab fa-stack-overflow"
-  desc = "Practical questions and curated answers"
+  name ="Mastodon"
+  url = "https://mastodon.social/@SpinKube"
+  icon = "fab fa-mastodon"
+  desc = "Follow us on Mastodon to get the latest SpinKube news!"
+#[[params.links.user]]
+#  name = "Stack Overflow"
+#  url = "https://example.org/stack"
+#  icon = "fab fa-stack-overflow"
+#  desc = "Practical questions and curated answers"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
   name = "GitHub"
   url = "https://github.com/spinkube"
   icon = "fab fa-github"
   desc = "Development takes place here!"
+#[[params.links.developer]]
+#  name = "Slack"
+#  url = "https://example.org/slack"
+#  icon = "fab fa-slack"
+#  desc = "Chat with other project developers"
 [[params.links.developer]]
-  name = "Slack"
-  url = "https://example.org/slack"
-  icon = "fab fa-slack"
-  desc = "Chat with other project developers"
-[[params.links.developer]]
-  name = "Developer mailing list"
-  url = "https://example.org/mail"
+  name = "Email"
+  url = "mailto:spinkubemaintainers@gmail.com"
   icon = "fa fa-envelope"
-  desc = "Discuss development issues around the project"
+  desc = "SpinKube Maintainers email."
 
 # hugo module configuration
 


### PR DESCRIPTION
Update to include Mastodon, email and GitHub only (removed Stack Overflow and Slack)

Before:

![Screenshot 2024-03-08 at 11 40 19](https://github.com/spinkube/documentation/assets/9831342/1b5c0304-35b8-487e-aab0-c5d555959173)

After:

![Screenshot 2024-03-08 at 11 38 47](https://github.com/spinkube/documentation/assets/9831342/b83a4391-2045-4ffa-b0f0-5e3b0f462c9b)
