### PR TITLE
A clean way to remove i18n, for now

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -62,20 +62,6 @@ weight = 1
 title = "SpinKube"
 description = "A new open source project that streamlines the experience of developing, deploying, and operating Wasm workloads on Kubernetes."
 
-#[languages.no]
-#languageName ="Norsk"
-#contentDir = "content/no"
-#[languages.no.params]
-#title = "SpinKube"
-#description = "Et nytt åpen kildekode-prosjekt som effektiviserer opplevelsen av å utvikle, distribuere og drifte Wasm-arbeidsbelastninger på Kubernetes."
-
-#[languages.de]
-#languageName ="Deutsch"
-#contentDir = "content/de"
-#[languages.de.params]
-#title = "SpinKube"
-#description = "Ein neues Open-Source-Projekt, das die Erfahrung bei der Entwicklung, Bereitstellung und dem Betrieb von Wasm-Workloads auf Kubernetes optimiert."
-
 time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 


### PR DESCRIPTION
Before:

![Screenshot 2024-03-08 at 11 59 01](https://github.com/spinkube/documentation/assets/9831342/6658260f-6131-4924-9ffc-98c63031bcac)

After:

![Screenshot 2024-03-08 at 11 59 11](https://github.com/spinkube/documentation/assets/9831342/a22671c8-d517-4fd5-89a5-000c1dd20725)

What's next:

**We can add back any translation / i18n in the future**