### PR TITLE
docs: Give categories weight for better IA

### DIFF
--- a/content/en/docs/containerd-shim-spin/_index.md
+++ b/content/en/docs/containerd-shim-spin/_index.md
@@ -3,7 +3,7 @@ title: containerd-shim-spin
 description: The Containerd Shim Spin is a project that integrates WebAssembly (Wasm) and WASI workloads into Kubernetes.
 categories: [Containerd Shim Spin]
 tags: [containerd-shim-spin]
-weight: 100
+weight: 60
 ---
 
 The [Containerd Shim Spin repository](https://github.com/spinkube/containerd-shim-spin), or "contained-shim-spin," provides shim implementations for running WebAssembly ([Wasm](https://webassembly.org/)) / Wasm System Interface ([WASI](https://github.com/WebAssembly/WASI)) workloads using [runwasi](https://github.com/deislabs/runwasi) as a library, whereby workloads built using the [Spin framework](https://github.com/fermyon/spin) can function similarly to container workloads in a Kubernetes environment. 

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: A high level overview of the SpinKube sub-projects 
-weight: 100
+weight: 1
 categories: [SpinKube]
 tags: [Overview]
 ---

--- a/content/en/docs/runtime-class-manager/_index.md
+++ b/content/en/docs/runtime-class-manager/_index.md
@@ -3,7 +3,7 @@ title: runtime-class-manager
 description: Enhance Kubernetes with Runtime-Class-Manager; efficient Containerd shim handling.
 categories: [Runtime Class Manager]
 tags: [runtime-class-manager]
-weight: 100
+weight: 70
 ---
 
 The [Runtime Class Manager, also known as the Containerd Shim Lifecycle Operator](https://github.com/spinkube/runtime-class-manager), is designed to automate and manage the lifecycle of containerd shims in a Kubernetes environment. This includes tasks like installation, update, removal, and configuration of shims, reducing manual errors and improving reliability in managing WebAssembly (Wasm) workloads and other containerd extensions.

--- a/content/en/docs/spin-operator/_index.md
+++ b/content/en/docs/spin-operator/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Spin Operator
+title: spin-operator
 description: Spin Operator
 categories: [Spin Operator]
 tags: [Spin Operator]
-weight: 100
+weight: 50
 ---
 
 ### What Is Spin Operator?

--- a/content/en/docs/spin-plugin-kube/_index.md
+++ b/content/en/docs/spin-plugin-kube/_index.md
@@ -3,7 +3,7 @@ title: spin-plugin-kube
 description: Enhance Kubernetes by enabling the execution of Wasm modules directly within a Kubernetes cluster
 categories: []
 tags: []
-weight: 100
+weight: 80
 ---
 
 The [Kubernetes plugin for Spin](https://github.com/spinkube/spin-plugin-kube) is designed to enhance Spin by enabling the execution of Wasm modules directly within a Kubernetes cluster. Specifically a tool designed for Kubernetes integration with the Spin command-line interface. This plugin works by integrating with containerd shims, allowing Kubernetes to manage and run Wasm workloads in a way similar to traditional container workloads.


### PR DESCRIPTION
The docs navigation is currently jumbled, without a consistent order for documentation. This PR gives weight to the content - the highest for the Overview, so it sticks to the top, then a descending order for the spin-operator, shim, class-manager, and spin-plugin based partially on the order that we expect folks to discover them in.

Live:

![image](https://github.com/spinkube/documentation/assets/1330683/04f87d63-b8dc-4048-acc0-1b7183811975)


Now:

![image](https://github.com/spinkube/documentation/assets/1330683/c45ef0b2-95ee-428e-89bc-ef21eac73f7c)
