### PR TITLE
docs(*): update manifest URLs to use release artifacts

### DIFF
--- a/content/en/docs/glossary/_index.md
+++ b/content/en/docs/glossary/_index.md
@@ -106,6 +106,10 @@ However, the `SpinApp` manifest currently supports configuring options such as:
 - volume mounts
 - autoscaling
 
+## Spin App Executor (CRD)
+
+The `SpinAppExecutor` CRD is a [Custom Resource Definition](#custom-resource-definition-crd) utilized by Spin Operator to determine which executor type should be used in running a SpinApp.
+
 ## Spin Operator
 
 Spin Operator is a Kubernetes operator in charge of handling the lifecycle of Spin applications based on their SpinApp resources.

--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -16,15 +16,6 @@ For this guide in particular, you will need:
 - [kubectl]({{< ref "prerequisites#kubectl" >}}) - the Kubernetes CLI
 - [Helm]({{< ref "prerequisites#helm" >}}) - the package manager for Kubernetes
 
-<!-- NOTE: remove this prerequisite when the runtime-class and CRDs can be applied from their release artifacts, i.e. when repo and release are public -->
-
-Also, ensure you have cloned this repository and have navigated to the root of the project:
-
-```console
-git clone git@github.com:spinkube/spin-operator.git
-cd spin-operator
-```
-
 ## Install Spin Operator With Helm
 
 The following instructions are for installing Spin Operator using a Helm chart (using `helm install`).
@@ -35,10 +26,8 @@ Before installing the chart, you'll need to ensure the following:
 
 The [Custom Resource Definition (CRD)]({{< ref "glossary#custom-resource-definition-crd" >}}) resources are installed. This includes the `SpinApp` CRD representing Spin applications to be scheduled on the cluster.
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
-
 ```console
-make install
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.crds.yaml
 ```
 
 A [RuntimeClass]({{< ref "glossary#runtime-class" >}}) resource class that
@@ -46,10 +35,15 @@ points to the `spin` handler called `wasmtime-spin-v2` will be created. If you
 are deploying to a production cluster that only has a shim on a subset of nodes,
 you'll need to modify the RuntimeClass with a `nodeSelector:`.
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
+```console
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.runtime-class.yaml
+```
+
+The `containerd-spin-shim` [SpinAppExecutor]({{< ref "glossary#spin-app-executor-crd" >}}) custom resource is installed. This
+tells Spin Operator to use the containerd shim executor to run Spin apps:
 
 ```console
-kubectl apply -f config/samples/spin-runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.shim-executor.yaml
 ```
 
 ## Chart prerequisites
@@ -82,14 +76,12 @@ The spin-operator chart currently includes the following sub-charts:
 
 The following installs the chart with the release name `spin-operator`:
 
-<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
-
 ```shell
 # Install Spin Operator with Helm
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --devel \
+  --version 0.0.1 \
   --wait \
   oci://ghcr.io/spinkube/spin-operator
 ```
@@ -98,21 +90,17 @@ helm install spin-operator \
 
 Note that you may also need to upgrade the spin-operator CRDs in tandem with upgrading the Helm release:
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
-
 ```
-make install
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.crds.yaml
 ```
 
 To upgrade the `spin-operator` release, run the following:
-
-<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
 
 ```shell
 # Upgrade Spin Operator using Helm
 helm upgrade spin-operator \
   --namespace spin-operator \
-  --devel \
+  --version 0.0.1 \
   --wait \
   oci://ghcr.io/spinkube/spin-operator
 ```
@@ -130,17 +118,10 @@ This will remove all Kubernetes resources associated with the chart and deletes 
 
 To completely uninstall all resources related to spin-operator, you may want to delete the corresponding CRD resources and, optionally, the RuntimeClass:
 
-<!-- TODO: replace with:
 ```console
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml
-
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml
-```
--->
-
-```console
-make uninstall
-kubectl delete -f config/samples/spin-runtime-class.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.crds.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.runtime-class.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.shim-executor.yaml
 ```
 
 <!-- TODO: list out configuration options? -->

--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -21,8 +21,6 @@ For this Quickstart in particular, you will need:
 - [k3d]({{< ref "prerequisites#k3d" >}}) - a lightweight Kubernetes distribution that runs on Docker
 - [Docker]({{< ref "prerequisites#docker" >}}) - for running k3d
 
-<!-- NOTE: remove this prerequisite when the runtime-class and CRDs can be applied from their release artifacts, i.e. when repo and release are public -->
-
 Also, ensure you have cloned this repository and have navigated to the root of the project:
 
 ```console
@@ -34,7 +32,7 @@ cd spin-operator
 
 1. Create a Kubernetes cluster with a k3d image that includes the [containerd-shim-spin](https://github.com/spinkube/containerd-shim-spin) prerequisite already installed:
 
-<!-- TODO: update below with ghcr.io/spinkube/containerd-shim-spin/examples/k3d:<tag> -->
+<!-- TODO: update below with ghcr.io/spinkube/containerd-shim-spin/k3d:<tag> -->
 
 ```console
 k3d cluster create wasm-cluster \
@@ -57,18 +55,15 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 > Note: In a production cluster you likely want to customize the runtimeClass with a `nodeSelector:` that matches nodes that have the shim installed. In the K3D example they're installed on every node. 
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
-
 ```console
-kubectl apply -f config/samples/spin-runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.runtime-class.yaml
 ```
 
 4. Apply the [Custom Resource Definitions](../../glossary#custom-resource-definition-crd) used by the Spin Operator:
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
 
 ```console
-make install
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.crds.yaml
 ```
 
 ## Deploy the Spin Operator
@@ -84,18 +79,14 @@ make deploy IMG=ghcr.io/spinkube/spin-operator:dev
 Lastly, create the shim executor:
 
 ```console
-kubectl apply -f config/samples/spin-shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.shim-executor.yaml
 ```
 
 ## Run the Sample Application
 
 You are now ready to deploy Spin applications onto the cluster!
 
-<!-- TODO: if/when we have the option and if we wanted to, we could mention that the kwasm operator isn't needed when using k3d, as the containerd-shim-spin is already present. Installation could be skipped via --set kwasm-operator.enabled=false -->
-
 1. Create your first application in the same `spin-operator` namespace that the operator is running:
-
-<!-- Note: the default 'containerd-shim-spin' SpinAppExecutor CR needs to be present on the cluster before apps using this default can run. However, as of writing, it is a namespaced resource. As such, apps can only be deployed in the same namespace(s) that the CR is present. -->
 
 ```console
 kubectl apply -f config/samples/simple.yaml

--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -72,20 +72,21 @@ kube-system       Active   3m
 
 First, the [Custom Resource Definition (CRD)]({{< ref "/docs/glossary/_index.md#custom-resource-definition-crd" >}}) and the [Runtime Class]({{< ref "glossary#runtime-class" >}}) for `wasmtime-spin-v2` must be installed.
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
 
 ```shell
-# Install the CRD
-make install
+# Install the CRDs
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.crds.yaml
 
 # Install the RuntimeClass
-kubectl apply -f config/samples/spin-runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.runtime-class.yaml
+
+# Install the SpinAppExecutor
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.1/spin-operator.shim-executor.yaml
 ```
 
 The following installs [Cert Manager](https://github.com/cert-manager/cert-manager) which is required to automatically provision and manage TLS certificates (used by spin-operator's admission webhook system)
 
-```
+```shell
 helm repo add jetstack https://charts.jetstack.io
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
@@ -96,13 +97,11 @@ helm install cert-manager jetstack/cert-manager \
 
 The following installs the chart with the release name `spin-operator`:
 
-<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
-
 ```shell
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --devel \
+  --version 0.0.1 \
   --wait \
   oci://ghcr.io/spinkube/spin-operator
 ```


### PR DESCRIPTION
- update manifest URLs to use release artifacts
  - Note: the [v0.0.1](https://github.com/spinkube/spin-operator/releases/tag/v0.0.1) release doesn't yet have the shim-executor.yaml due to a bug since fixed (https://github.com/spinkube/spin-operator/pull/153);  currently seeing if an admin can add it to the release retroactively.
- add Spin App Executor to glossary per added reference

This sets things up so that when v0.1.0 is released (or whatever next version), we can string replace `0.0.1` w/ `<version>`