### PR TITLE
Add Google Custom Search for spinkube.dev

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -120,7 +120,7 @@ github_project_repo = "https://github.com/spinkube/spin-operator"
 github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "d72aa9b2712488cc3"
+gcs_engine_id = "d774df95371c74907"
 
 # Enable Lunr.js offline search
 offlineSearch = false


### PR DESCRIPTION
An instance of Google Custom Search (GCS) has been added and configured to index contents from *.spinkube.dev/*

The GCS has been created using the spin.maintainers@gmail.com account.

fixes #1