### PR TITLE
Unify cert-manager version across docs

### DIFF
--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -50,7 +50,7 @@ k3d cluster create wasm-cluster \
 2. Install cert manager
 
 ```console
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
 ```
 
 3. Apply the [Runtime Class](https://github.com/spinkube/spin-operator/blob/main/config/samples/spin-runtime-class.yaml) used for scheduling Spin apps onto nodes running the shim:

--- a/content/en/docs/spin-operator/tutorials/running-on-a-cluster.md
+++ b/content/en/docs/spin-operator/tutorials/running-on-a-cluster.md
@@ -19,7 +19,7 @@ This is the standard development workflow for when you want to test running Spin
 To install cert-manager with the default config
 
 ```console
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
 ```
 
 Deploy the Manager to the cluster with the image specified by `IMG`:


### PR DESCRIPTION
We had a mix of two cert-manager versions being mentioned (`1.14.2` and `1.14.3`). With this commit all instructions point to cert-manager `1.14.3`.

fixes #69