### PR TITLE
docs: Order sidenav items to match user flow

### DIFF
--- a/content/en/docs/spin-operator/contributing/_index.md
+++ b/content/en/docs/spin-operator/contributing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-weight: 100
+weight: 6
 description: >
   Contributing to Spin Operator 
 categories: [Spin Operator]

--- a/content/en/docs/spin-operator/installation/_index.md
+++ b/content/en/docs/spin-operator/installation/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation
 description: Learn how to install Spin Operator
-weight: 100
+weight: 3
 categories: [Spin Operator]
 tags: [Installation]
 ---

--- a/content/en/docs/spin-operator/prerequisites/_index.md
+++ b/content/en/docs/spin-operator/prerequisites/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Prerequisites
 description: Prerequisites
-weight: 100
+weight: 1
 categories: [Spin Operator]
 tags: [Prerequisites]
 ---

--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -3,7 +3,7 @@ title: Quickstart
 description: What does your user need to know to try your project?
 categories: [Spin Operator]
 tags: [Quickstart]
-weight: 100
+weight: 2
 ---
 
 # Quickstart

--- a/content/en/docs/spin-operator/support/_index.md
+++ b/content/en/docs/spin-operator/support/_index.md
@@ -3,6 +3,6 @@ title: Support
 description: This section provides support resources in the context of Spin Operator
 categories: [Spin Operator]
 tags: [Support]
-weight: 100
+weight: 5
 ---
 

--- a/content/en/docs/spin-operator/tutorials/_index.md
+++ b/content/en/docs/spin-operator/tutorials/_index.md
@@ -2,7 +2,7 @@
 title: Tutorials
 description: This section consists of tutorials in the context of Spin Operator
 date: 2024-02-16
-weight: 100
+weight: 4
 categories: [Spin Operator]
 tags: [Tutorials]
 ---

--- a/content/en/docs/spin-plugin-kube/concepts/_index.md
+++ b/content/en/docs/spin-plugin-kube/concepts/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-weight: 100
+weight: 4
 description: >
   The Spin Plugin for Kubernetes is a Spin plugin for interacting with Kubernetes.
 categories: [reference]

--- a/content/en/docs/spin-plugin-kube/contributing/_index.md
+++ b/content/en/docs/spin-plugin-kube/contributing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-weight: 100
+weight: 5
 description: >
   Contributing to the Spin plugin for Kubernetes
 categories: [contributing]

--- a/content/en/docs/spin-plugin-kube/installation/_index.md
+++ b/content/en/docs/spin-plugin-kube/installation/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation
 description: Learn how to install the `kube` plugin for `spin`
-weight: 100
+weight: 1
 categories: [guides]
 tags: [plugins, kubernetes, spin]
 ---

--- a/content/en/docs/spin-plugin-kube/reference/_index.md
+++ b/content/en/docs/spin-plugin-kube/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 description: Spin Plugin kube CLI Reference
-weight: 100
+weight: 3
 categories: [reference]
 tags: [plugins]
 ---

--- a/content/en/docs/spin-plugin-kube/tutorials/_index.md
+++ b/content/en/docs/spin-plugin-kube/tutorials/_index.md
@@ -2,7 +2,7 @@
 title: Tutorials
 description: This section consists of tutorials in the context of the Kubernetes plugin for Spin
 date: 2024-02-16
-weight: 100
+weight: 2
 categories: []
 tags: []
 ---


### PR DESCRIPTION
Fixes the order of entries in the side navigation bar to be more closely aligned with the user flow. 

![image](https://github.com/spinkube/documentation/assets/25023490/43968383-416c-47ae-82f8-9d43e9c4bf60)
![image](https://github.com/spinkube/documentation/assets/25023490/61f7785a-1cfe-4370-93f9-049adbff6ced)
