### PR TITLE
Add individual descriptions for Spin Operator tutorials

### DIFF
--- a/content/en/docs/spin-operator/tutorials/package-and-deploy.md
+++ b/content/en/docs/spin-operator/tutorials/package-and-deploy.md
@@ -1,6 +1,6 @@
 ---
 title: Package and Deploy Spin Apps
-description: A short lead description about this content page. It can be **bold** or _italic_ and can be split over multiple paragraphs.
+description: Learn how to package and distribute Spin Apps using either public or private OCI compliant registries
 date: 2024-02-16
 weight: 4
 categories: [Spin Operator]

--- a/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
@@ -1,7 +1,6 @@
 ---
 title: Scaling Spin App With Horizontal Pod Autoscaling (HPA)
-description: >
-  A short lead description about this content page. It can be **bold** or _italic_ and can be split over multiple paragraphs.
+description: This tutorial illustrates how one can horizontally scale Spin Apps in Kubernetes using Horizontal Pod Autscaling (HPA)
 date: 2024-02-16
 categories: [Spin Operator]
 tags: [Tutorials]

--- a/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
@@ -1,7 +1,6 @@
 ---
 title: Scaling Spin App With Kubernetes Event-Driven Autoscaling (KEDA)
-description: >
-  A short lead description about this content page. It can be **bold** or _italic_ and can be split over multiple paragraphs.
+description: This tutorial illustrates how one can horizontally scale Spin Apps in Kubernetes using Kubernetes Event-Driven Autoscaling (KEDA)
 date: 2024-02-16
 categories: [Spin Operator]
 tags: [Tutorials]

--- a/content/en/docs/spin-operator/tutorials/share-operator-image.md
+++ b/content/en/docs/spin-operator/tutorials/share-operator-image.md
@@ -1,6 +1,6 @@
 ---
 title: Share Spin Operator Image
-description: How to build and push the Spin Operator image
+description: Discover how to build and push the Spin Operator image
 date: 2024-02-16
 categories: [Spin Operator]
 tags: [Tutorials]


### PR DESCRIPTION
This commit adds descriptions to different Spin Operator tutorials. Those descriptions are shown at https://www.spinkube.dev/docs/spin-operator/tutorials/

fixes #75