### PR TITLE
Add Quickstart to top level TOC

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Quickstart
+description: Learn how to setup a Kubernetes cluser, install the Spin Operator and run your first Spin App
+weight: 2
+manualLinkRelref: ../spin-operator/quickstart
+categories: [Spin Operator]
+tags: [Quickstart]
+---
+
+<!--- This page is used to render a link to the Spin Operator Quickstart in the TOC -->


### PR DESCRIPTION
With this commit, a manual link to the Spin Operator Quickstart is added to the top-level TOC