### PR TITLE
Update Spin Operator chart source

### DIFF
--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -92,7 +92,7 @@ helm install spin-operator \
   --create-namespace \
   --devel \
   --wait \
-  oci://ghcr.io/spinkube/spin-operator
+  oci://ghcr.io/spinkube/charts/spin-operator
 ```
 
 ### Upgrading the Chart
@@ -115,7 +115,7 @@ helm upgrade spin-operator \
   --namespace spin-operator \
   --devel \
   --wait \
-  oci://ghcr.io/spinkube/spin-operator
+  oci://ghcr.io/spinkube/charts/spin-operator
 ```
 
 ### Uninstalling the Chart

--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -104,7 +104,7 @@ helm install spin-operator \
   --create-namespace \
   --devel \
   --wait \
-  oci://ghcr.io/spinkube/spin-operator
+  oci://ghcr.io/spinkube/charts/spin-operator
 ```
 
 The Spin Operator chart has a dependency on [Kwasm](https://kwasm.sh/), which you use to install `containerd-wasm-shim` on the Kubernetes node(s):


### PR DESCRIPTION
With v0.0.2 the location of the Helm chart for Spin Operator has changed. This commit changes all docs to use the new location