### PR TITLE
docs(*): address TODOs; update k3d img; set node-installer img; misc

### DIFF
--- a/content/en/docs/glossary/_index.md
+++ b/content/en/docs/glossary/_index.md
@@ -45,7 +45,7 @@ spec:
   runtime: "containerd-shim-spin"
 ```
 
-> SpinApp CRDs are kept separate from Helm. If using Helm, CustomResourceDefinition (CRD) resources will need to be installed prior to installing the Heml chart.
+> SpinApp CRDs are kept separate from Helm. If using Helm, CustomResourceDefinition (CRD) resources will need to be installed prior to installing the Helm chart.
 
 ## Helm
 
@@ -105,6 +105,10 @@ However, the `SpinApp` manifest currently supports configuring options such as:
 - Spin variables
 - volume mounts
 - autoscaling
+
+## Spin App Executor (CRD)
+
+The `SpinAppExecutor` CRD is a [Custom Resource Definition](#custom-resource-definition-crd) utilized by Spin Operator to determine which executor type should be used in running a SpinApp.
 
 ## Spin Operator
 

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -20,6 +20,6 @@ All of this while being able to integrate with with Kubernetes primitives (DNS, 
 
 ![SpinKube Project Overview Diagram](/static/spinkube-overview-diagram.png)
 
-Spin Operator watches Spin App Custom Resources and realizes the desired state in the Kubernetes cluster. The foundation of this project was built using the kubebuilder framework and contains a Spin App Custom Resource Definition (CRD) and controller.
+Spin Operator watches [Spin App Custom Resources]({{< ref "glossary#spinapp-manifest" >}}) and realizes the desired state in the Kubernetes cluster. The foundation of this project was built using the kubebuilder framework and contains a Spin App Custom Resource Definition (CRD) and controller.
 
 To get started, check out our [Spin Operator quickstart](../spin-operator/quickstart/_index.md). 

--- a/content/en/docs/spin-operator/_index.md
+++ b/content/en/docs/spin-operator/_index.md
@@ -22,7 +22,7 @@ Built with the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) fra
 
 ![](spin-operator-diagram.png)
 
-SpinApps CRDs can be [composed manually](../glossary/_index.md/#custom-resource-definition-crd) or generated automatically from an existing Spin application using the [`spin kube scaffold`](../spin-plugin-kube/_index.md) command. The former approach lends itself well to CI/CD systems, whereas the latter is a better fit for local testing as part of a local developer workflow. 
+SpinApps CRDs can be [composed manually](../glossary/_index.md/#custom-resource-definition-crd) or generated automatically from an existing Spin application using the [`spin kube scaffold`](../spin-plugin-kube/_index.md) command. The former approach lends itself well to CI/CD systems, whereas the latter is a better fit for local testing as part of a local developer workflow.
 
 Once an application deployment begins, Spin Operator handles scheduling the workload on the appropriate nodes (thanks to the [Runtime Class Manager](../runtime-class-manager/), previously known as Kwasm) and managing the resource's lifecycle. There is no need to fetch the [containerd shim spin]((../containerd-shim-spin/) ) binary or mutate node labels. This is all managed via the Runtime Class Manager, which you will install as a dependency when setting up Spin Operator. 
 

--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -24,9 +24,7 @@ The following instructions are for installing Spin Operator using a Helm chart (
 
 Before installing the chart, you'll need to ensure the following:
 
-The [Custom Resource Definition (CRD)]({{< ref "glossary#custom-resource-definition-crd" >}}) resources are installed. This includes the `SpinApp` CRD representing Spin applications to be scheduled on the cluster.
-
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
+The [Custom Resource Definition (CRD)]({{< ref "glossary#custom-resource-definition-crd" >}}) resources are installed. This includes the SpinApp CRD representing Spin applications to be scheduled on the cluster.
 
 ```console
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
@@ -37,10 +35,15 @@ points to the `spin` handler called `wasmtime-spin-v2` will be created. If you
 are deploying to a production cluster that only has a shim on a subset of nodes,
 you'll need to modify the RuntimeClass with a `nodeSelector:`.
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
-
 ```console
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+```
+
+The `containerd-spin-shim` [SpinAppExecutor]({{< ref "glossary#spin-app-executor-crd" >}}) custom resource is installed. This
+tells Spin Operator to use the containerd shim executor to run Spin apps:
+
+```console
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
 ```
 
 ## Chart prerequisites
@@ -65,15 +68,16 @@ helm install \
 
 - [Kwasm Operator](https://github.com/kwasm/kwasm-operator) is required to install WebAssembly support on Kubernetes nodes. Note in the future this will be replaced by [runtime class manager](../../runtime-class-manager/_index.md). 
 
-<!-- TODO: When we have a node-installer img published from spinkube/containerd-shim-spin, we'll update the helm install step below to --set with that override.  
--->
-
 ```shell
 # Add Helm repository if not already done
 helm repo add kwasm http://kwasm.sh/kwasm-operator/
 
 # Install KWasm operator
-helm install -n kwasm --create-namespace kwasm-operator kwasm/kwasm-operator
+helm install \
+  kwasm-operator kwasm/kwasm-operator \
+  --namespace kwasm \
+  --create-namespace \
+  --set kwasmOperator.installerImage=ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.12.0
 
 # Provision Nodes
 kubectl annotate node --all kwasm.sh/kwasm-node=true
@@ -83,14 +87,13 @@ kubectl annotate node --all kwasm.sh/kwasm-node=true
 
 The following installs the chart with the release name `spin-operator`:
 
-<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
 
 ```shell
 # Install Spin Operator with Helm
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --devel \
+  --version 0.0.2 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -99,21 +102,17 @@ helm install spin-operator \
 
 Note that you may also need to upgrade the spin-operator CRDs in tandem with upgrading the Helm release:
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
-
 ```shell
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
 ```
 
 To upgrade the `spin-operator` release, run the following:
 
-<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
-
 ```shell
 # Upgrade Spin Operator using Helm
 helm upgrade spin-operator \
   --namespace spin-operator \
-  --devel \
+  --verson 0.0.2 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -131,17 +130,10 @@ This will remove all Kubernetes resources associated with the chart and deletes 
 
 To completely uninstall all resources related to spin-operator, you may want to delete the corresponding CRD resources and, optionally, the RuntimeClass:
 
-<!-- TODO: replace with:
-```console
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml
-
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml
-```
--->
-
 ```console
 kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
 kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
 ```
 
 <!-- TODO: list out configuration options? -->

--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -29,11 +29,9 @@ cd spin-operator
 
 1. Create a Kubernetes cluster with a k3d image that includes the [containerd-shim-spin](https://github.com/spinkube/containerd-shim-spin) prerequisite already installed:
 
-<!-- TODO: update below with ghcr.io/spinkube/containerd-shim-spin/examples/k3d:<tag> -->
-
 ```console
 k3d cluster create wasm-cluster \
-  --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 \
+  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 \
   --port "8081:80@loadbalancer" \
   --agents 2
 ```
@@ -52,15 +50,11 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 > Note: In a production cluster you likely want to customize the Runtime Class with a `nodeSelector` that matches nodes that have the shim installed. However, in the K3d example, they're installed on every node. 
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
-
 ```console
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
 ```
 
 4. Apply the [Custom Resource Definitions](../../glossary#custom-resource-definition-crd) used by the Spin Operator:
-
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
 
 ```console
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
@@ -76,9 +70,7 @@ k3d image import -c wasm-cluster ghcr.io/spinkube/spin-operator:dev
 make deploy IMG=ghcr.io/spinkube/spin-operator:dev
 ```
 
-Lastly, create the shim executor:
-
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.executor.yaml' -->
+Lastly, create the [shim executor]({{< ref "glossary#spin-app-executor-crd" >}}):
 
 ```console
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
@@ -88,11 +80,7 @@ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.
 
 You are now ready to deploy Spin applications onto the cluster!
 
-<!-- TODO: if/when we have the option and if we wanted to, we could mention that the kwasm operator isn't needed when using k3d, as the containerd-shim-spin is already present. Installation could be skipped via --set kwasm-operator.enabled=false -->
-
 1. Create your first application in the same `spin-operator` namespace that the operator is running:
-
-<!-- Note: the default 'containerd-shim-spin' SpinAppExecutor CR needs to be present on the cluster before apps using this default can run. However, as of writing, it is a namespaced resource. As such, apps can only be deployed in the same namespace(s) that the CR is present. -->
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/samples/simple.yaml

--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -73,9 +73,6 @@ kube-system       Active   3m
 
 First, the [Custom Resource Definition (CRD)]({{< ref "/docs/glossary/_index.md#custom-resource-definition-crd" >}}) and the [Runtime Class]({{< ref "glossary#runtime-class" >}}) for `wasmtime-spin-v2` must be installed.
 
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
-
 ```shell
 # Install the CRDs
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
@@ -98,7 +95,7 @@ helm repo update
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.13.3
+  --version v1.14.3
 ```
 
 The Spin Operator chart also has a dependency on [Kwasm](https://kwasm.sh/), which you use to install `containerd-wasm-shim` on the Kubernetes node(s):
@@ -112,9 +109,11 @@ helm repo add kwasm http://kwasm.sh/kwasm-operator/
 helm repo update
 
 # Install KWasm operator
-helm install kwasm-operator kwasm/kwasm-operator \
+helm install \
+  kwasm-operator kwasm/kwasm-operator \
   --namespace kwasm \
-  --create-namespace 
+  --create-namespace \
+  --set kwasmOperator.installerImage=ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.12.0
 
 # Provision Nodes
 kubectl annotate node --all kwasm.sh/kwasm-node=true
@@ -132,20 +131,16 @@ kubectl logs -n kwasm -l app.kubernetes.io/name=kwasm-operator
 
 The following installs the chart with the release name `spin-operator` in the `spin-operator` namespace:
 
-<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
-
 ```shell
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --devel \
+  --version 0.0.2 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
 
-Lastly, create the shim executor:
-
-<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.executor.yaml' -->
+Lastly, create the [shim executor]({{< ref "glossary#spin-app-executor-crd" >}})::
 
 ```console
 kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml

--- a/content/en/docs/spin-operator/tutorials/running-locally.md
+++ b/content/en/docs/spin-operator/tutorials/running-locally.md
@@ -31,7 +31,7 @@ Run the following command to create a Kubernetes k3d cluster that has [the
 containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims) pre-requisites installed:
 
 ```console
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 -p "8081:80@loadbalancer" --agents 2
 ```
 
 Run the following command to install the Custom Resource Definitions (CRDs) into the cluster:

--- a/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
@@ -35,7 +35,7 @@ cd spin-operator
 Run the following command to create a Kubernetes cluster that has [the containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims) pre-requisites installed: If you have a Kubernetes cluster already, please feel free to use it:
 
 ```console
-k3d cluster create wasm-cluster-scale --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster-scale --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 -p "8081:80@loadbalancer" --agents 2
 ```
 
 Next, from within the `spin-operator` directory, run the following commands to install the Spin runtime class and Spin Operator:

--- a/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
@@ -40,7 +40,7 @@ cd spin-operator
 Run the following command to create a Kubernetes cluster that has [the containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims) pre-requisites installed: If you have a Kubernetes cluster already, please feel free to use it:
 
 ```console
-k3d cluster create wasm-cluster-scale --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster-scale --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 -p "8081:80@loadbalancer" --agents 2
 ```
 
 Next, from within the `spin-operator` directory, run the following commands to install the Spin runtime class and Spin Operator:

--- a/content/en/docs/spin-operator/tutorials/spin-operator-development.md
+++ b/content/en/docs/spin-operator/tutorials/spin-operator-development.md
@@ -34,7 +34,7 @@ make install
 **Deploy cert-manager to the cluster:**
 
 ```console
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
 ```
 
 > **NOTE**: Cert-manager is required to manage the TLS certificates for the admission webhooks.
@@ -86,7 +86,7 @@ make undeploy
 **UnDeploy cert-manager from the cluster:**
 
 ```console
-kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
 ```
 
 ### Packaging and deployment via Helm


### PR DESCRIPTION
- address/delete TODOs
- update k3d img via the [v0.12.0 containerd-shim-spin release](https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.12.0)
  - cc @kate-goldenring to double-check shim release schedule and if we'll want/need to update this again soon.
- set node-installer image during kwasm-operator install steps, from same release ^^
- add SpinAppExecutor CRD entry to glossary
- some spots where we weren't instructing to install the shim-executor
- some spots to align cert-manager version across docs (to v1.14.3)