### PR TITLE
Bump Spin Operator refs to 0.1.0

### DIFF
--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -27,7 +27,7 @@ Before installing the chart, you'll need to ensure the following:
 The [Custom Resource Definition (CRD)]({{< ref "glossary#custom-resource-definition-crd" >}}) resources are installed. This includes the SpinApp CRD representing Spin applications to be scheduled on the cluster.
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
 ```
 
 A [RuntimeClass]({{< ref "glossary#runtime-class" >}}) resource class that
@@ -36,14 +36,14 @@ are deploying to a production cluster that only has a shim on a subset of nodes,
 you'll need to modify the RuntimeClass with a `nodeSelector:`.
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
 ```
 
 The `containerd-spin-shim` [SpinAppExecutor]({{< ref "glossary#spin-app-executor-crd" >}}) custom resource is installed. This
 tells Spin Operator to use the containerd shim executor to run Spin apps:
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
 ```
 
 ## Chart prerequisites
@@ -93,7 +93,7 @@ The following installs the chart with the release name `spin-operator`:
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.0.2 \
+  --version 0.1.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -103,7 +103,7 @@ helm install spin-operator \
 Note that you may also need to upgrade the spin-operator CRDs in tandem with upgrading the Helm release:
 
 ```shell
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
 ```
 
 To upgrade the `spin-operator` release, run the following:
@@ -112,7 +112,7 @@ To upgrade the `spin-operator` release, run the following:
 # Upgrade Spin Operator using Helm
 helm upgrade spin-operator \
   --namespace spin-operator \
-  --version 0.0.2 \
+  --version 0.1.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -131,9 +131,9 @@ This will remove all Kubernetes resources associated with the chart and deletes 
 To completely uninstall all resources related to spin-operator, you may want to delete the corresponding CRD resources and, optionally, the RuntimeClass:
 
 ```console
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
 ```
 
 <!-- TODO: list out configuration options? -->

--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -43,13 +43,13 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 > Note: In a production cluster you likely want to customize the Runtime Class with a `nodeSelector` that matches nodes that have the shim installed. However, in the K3d example, they're installed on every node. 
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
 ```
 
 4. Apply the [Custom Resource Definitions](../../glossary#custom-resource-definition-crd) used by the Spin Operator:
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
 ```
 
 ## Deploy the Spin Operator
@@ -61,7 +61,7 @@ Execute the following command to install the Spin Operator on the K3d cluster us
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.0.2 \
+  --version 0.1.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -69,7 +69,7 @@ helm install spin-operator \
 Lastly, create the [shim executor]({{< ref "glossary#spin-app-executor-crd" >}}):
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
 ```
 
 ## Run the Sample Application

--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -75,10 +75,10 @@ First, the [Custom Resource Definition (CRD)]({{< ref "/docs/glossary/_index.md#
 
 ```shell
 # Install the CRDs
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
 
 # Install the Runtime Class
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
 ```
 
 The following installs [cert-manager](https://github.com/cert-manager/cert-manager) which is required to automatically provision and manage TLS certificates (used by the admission webhook system of Spin Operator)
@@ -135,7 +135,7 @@ The following installs the chart with the release name `spin-operator` in the `s
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.0.2 \
+  --version 0.1.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -143,7 +143,7 @@ helm install spin-operator \
 Lastly, create the [shim executor]({{< ref "glossary#spin-app-executor-crd" >}})::
 
 ```console
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
 ```
 
 ## Deploying a Spin App to AKS

--- a/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
@@ -58,10 +58,10 @@ Next, run the following commands to install the Spin [Runtime Class]({{<ref "glo
 
 ```console
 # Install the RuntimeClass
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
 
 # Install the CRDs
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
 ```
 
 Lastly, install Spin Operator using `helm` and the [shim executor]({{< ref "glossary#spin-app-executor-crd" >}}) with the following commands:
@@ -71,12 +71,12 @@ Lastly, install Spin Operator using `helm` and the [shim executor]({{< ref "glos
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.0.2 \
+  --version 0.1.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 
 # Install the shim executor
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
 ```
 
 Great, now you have Spin Operator up and running on your cluster. This means you’re set to create and deploy SpinApps later on in the tutorial.

--- a/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
@@ -58,10 +58,10 @@ Next, run the following commands to install the Spin [Runtime Class]({{<ref "glo
 
 ```console
 # Install the RuntimeClass
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
 
 # Install the CRDs
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
 ```
 
 Lastly, install Spin Operator using `helm` and the [shim executor]({{< ref "glossary#spin-app-executor-crd" >}}) with the following commands:
@@ -71,12 +71,12 @@ Lastly, install Spin Operator using `helm` and the [shim executor]({{< ref "glos
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.0.2 \
+  --version 0.1.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 
 # Install the shim executor
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.0.2/spin-operator.shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
 ```
 
 Great, now you have Spin Operator up and running on your cluster. This means you’re set to create and deploy SpinApps later on in the tutorial.


### PR DESCRIPTION
With this commit, we move from v0.0.2 to `v0.1.0` when referring files/assets in the context of Spin Operator

This will fix #90 