### PR TITLE
Adding that Spin `2.3.1` is required for spin-plugin-kube.

### DIFF
--- a/content/en/docs/spin-operator/prerequisites/_index.md
+++ b/content/en/docs/spin-operator/prerequisites/_index.md
@@ -34,7 +34,7 @@ If running/deploying your Spin application involves the use of Helm, then the Sp
 
 ## Spin
 
-Please install the latest version of [Spin](https://developer.fermyon.com/spin/v2/install) on your local machine for creating Spin Apps.
+Please install the latest version ([2.3.1 or newer](https://developer.fermyon.com/spin/v2/upgrade)) of [Spin](https://developer.fermyon.com/spin/v2/install) on your local machine for creating Spin Apps.
 
 ## Bombardier
 

--- a/content/en/docs/spin-plugin-kube/installation/_index.md
+++ b/content/en/docs/spin-plugin-kube/installation/_index.md
@@ -14,7 +14,7 @@ Ensure the necessary [prerequisites]({{< ref "prerequisites" >}}) are installed.
 
 For this tutorial in particular, you will need
 
-- [spin]({{< ref "prerequisites#spin-cli" >}}) -  the Spin CLI ([version 2.3.1 or newer](https://developer.fermyon.com/spin/v2/upgrade))
+- [spin]({{< ref "prerequisites#spin" >}}) -  the Spin CLI ([version 2.3.1 or newer](https://developer.fermyon.com/spin/v2/upgrade))
 
 ## Install the plugin
 

--- a/content/en/docs/spin-plugin-kube/installation/_index.md
+++ b/content/en/docs/spin-plugin-kube/installation/_index.md
@@ -14,7 +14,7 @@ Ensure the necessary [prerequisites]({{< ref "prerequisites" >}}) are installed.
 
 For this tutorial in particular, you will need
 
-- [spin]({{< ref "prerequisites#spin-cli" >}}) - the Spin CLI
+- [spin]({{< ref "prerequisites#spin-cli" >}}) -  the Spin CLI ([version 2.3.1 or newer](https://developer.fermyon.com/spin/v2/upgrade))
 
 ## Install the plugin
 

--- a/content/en/docs/spin-plugin-kube/installation/_index.md
+++ b/content/en/docs/spin-plugin-kube/installation/_index.md
@@ -14,7 +14,7 @@ Ensure the necessary [prerequisites]({{< ref "prerequisites" >}}) are installed.
 
 For this tutorial in particular, you will need
 
-- [spin]({{< ref "prerequisites#spin" >}}) -  the Spin CLI ([version 2.3.1 or newer](https://developer.fermyon.com/spin/v2/upgrade))
+- [spin]({{< ref "prerequisites#spin" >}}) - the Spin CLI ([version 2.3.1 or newer](https://developer.fermyon.com/spin/v2/upgrade))
 
 ## Install the plugin
 


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com