### PR TITLE
chore: update examples to use latest `containerd` shim release

### DIFF
--- a/content/en/docs/spin-operator/installation/installing-with-helm.md
+++ b/content/en/docs/spin-operator/installation/installing-with-helm.md
@@ -77,7 +77,7 @@ helm install \
   kwasm-operator kwasm/kwasm-operator \
   --namespace kwasm \
   --create-namespace \
-  --set kwasmOperator.installerImage=ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.12.0
+  --set kwasmOperator.installerImage=ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.13.0
 
 # Provision Nodes
 kubectl annotate node --all kwasm.sh/kwasm-node=true

--- a/content/en/docs/spin-operator/quickstart/_index.md
+++ b/content/en/docs/spin-operator/quickstart/_index.md
@@ -25,7 +25,7 @@ For this Quickstart in particular, you will need:
 
 ```console
 k3d cluster create wasm-cluster \
-  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 \
+  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.13.0 \
   --port "8081:80@loadbalancer" \
   --agents 2
 ```

--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -113,7 +113,7 @@ helm install \
   kwasm-operator kwasm/kwasm-operator \
   --namespace kwasm \
   --create-namespace \
-  --set kwasmOperator.installerImage=ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.12.0
+  --set kwasmOperator.installerImage=ghcr.io/spinkube/containerd-shim-spin/node-installer:v0.13.0
 
 # Provision Nodes
 kubectl annotate node --all kwasm.sh/kwasm-node=true

--- a/content/en/docs/spin-operator/tutorials/running-locally.md
+++ b/content/en/docs/spin-operator/tutorials/running-locally.md
@@ -31,7 +31,7 @@ Run the following command to create a Kubernetes k3d cluster that has [the
 containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims) pre-requisites installed:
 
 ```console
-k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.13.0 -p "8081:80@loadbalancer" --agents 2
 ```
 
 Run the following command to install the Custom Resource Definitions (CRDs) into the cluster:

--- a/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-hpa.md
@@ -27,7 +27,7 @@ Run the following command to create a Kubernetes cluster that has [the container
 
 ```console
 k3d cluster create wasm-cluster-scale \
-  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 \
+  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.13.0 \
   -p "8081:80@loadbalancer" \
   --agents 2
 ```

--- a/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
+++ b/content/en/docs/spin-operator/tutorials/scaling-with-keda.md
@@ -27,7 +27,7 @@ Run the following command to create a Kubernetes cluster that has [the container
 
 ```console
 k3d cluster create wasm-cluster-scale \
-  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.12.0 \
+  --image ghcr.io/spinkube/containerd-shim-spin/k3d:v0.13.0 \
   -p "8081:80@loadbalancer" \
   --agents 2
 ```


### PR DESCRIPTION
v0.13.0 of the Spin containerd shim was just released:
https://github.com/spinkube/containerd-shim-spin/releases/tag/v0.13.0