### PR TITLE
Enable search without using GSC

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -120,10 +120,12 @@ github_project_repo = "https://github.com/spinkube/spin-operator"
 github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "d774df95371c74907"
+# gcs_engine_id = "d774df95371c74907"
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
+offlineSearchSummaryLength = 200
+offlineSearchMaxResults = 25
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false


### PR DESCRIPTION
Closes https://github.com/spinkube/documentation/issues/102

As we are using Plausible and the search is not working via the GSC configuration, this is a trial run of an alternate search method, following [these official Docsy instructions](https://www.docsy.dev/docs/adding-content/search/#local-search-with-lunr). It works on preview and hopefully will yield a good result on the site.

![Screenshot 2024-03-15 at 10 12 49](https://github.com/spinkube/documentation/assets/9831342/960f1568-59a6-4726-8a07-c47c80ed9a06)
