### PR TITLE
Update CRD reference title and location in TOC

### DIFF
--- a/content/en/docs/spin-operator/contributing/_index.md
+++ b/content/en/docs/spin-operator/contributing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-weight: 6
+weight: 7
 description: >
   Contributing to Spin Operator 
 categories: [Spin Operator]

--- a/content/en/docs/spin-operator/reference/_index.md
+++ b/content/en/docs/spin-operator/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reference
 description: Reference documentation for Custom Resource Definitions (CRDs)
-weight: 3
+weight: 6
 categories: [Spin Operator]
 tags: [reference]
 ---

--- a/content/en/docs/spin-operator/reference/spin-app-executor.md
+++ b/content/en/docs/spin-operator/reference/spin-app-executor.md
@@ -1,6 +1,6 @@
 ---
-title: SpinAppExecutor CRD Reference
-weight: 1
+title: SpinAppExecutor
+weight: 2
 description: Custom Resource Definition (CRD) reference for `SpinAppExecutor`
 categories: [Spin Operator]
 tags: [reference]

--- a/content/en/docs/spin-operator/reference/spin-app.md
+++ b/content/en/docs/spin-operator/reference/spin-app.md
@@ -1,5 +1,5 @@
 ---
-title: SpinApp CRD Reference
+title: SpinApp
 weight: 1
 description: Custom Resource Definition (CRD) reference for `SpinApp`
 categories: [Spin Operator]

--- a/crd-reference/spin-app-executor-toc.yaml
+++ b/crd-reference/spin-app-executor-toc.yaml
@@ -1,6 +1,6 @@
 metadata:
-  title: "SpinAppExecutor CRD Reference"
-  weight: 1
+  title: "SpinAppExecutor"
+  weight: 2
   description: "Custom Resource Definition (CRD) reference for `SpinAppExecutor`"
   category: Spin Operator
 groups:

--- a/crd-reference/spin-app-toc.yaml
+++ b/crd-reference/spin-app-toc.yaml
@@ -1,5 +1,5 @@
 metadata:
-  title: "SpinApp CRD Reference"
+  title: "SpinApp"
   weight: 1
   description: "Custom Resource Definition (CRD) reference for `SpinApp`"
 groups:


### PR DESCRIPTION
With this PR the reference docs for SpinApp and SpinAppExectutor receive new titles and are placed after support in the navigation

Closes #121 