### PR TITLE
Build the docs on PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -60,11 +63,13 @@ jobs:
             --baseURL "https://${{ env.CANONICAL_DOMAIN }}/"
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
   deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: Build only
+name: Build
 
 on:
   pull_request:
@@ -9,7 +9,6 @@ permissions:
   contents: read
 
 env:
-  CANONICAL_DOMAIN: www.spinkube.dev
   SPIN_OPERATOR_RELEASE: v0.1.0
 
 jobs:
@@ -42,5 +41,4 @@ jobs:
         run: |
           hugo \
             --gc \
-            --minify \
-            --baseURL "https://${{ env.CANONICAL_DOMAIN }}/"
+            --minify

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,28 +1,18 @@
-name: Deploy to GitHub Pages
+name: Build only
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 env:
   CANONICAL_DOMAIN: www.spinkube.dev
   SPIN_OPERATOR_RELEASE: v0.1.0
 
 jobs:
-  # TODO: place into separate build.yaml (and add PR support?) and then call here?
   build:
     runs-on: ubuntu-latest
     env:
@@ -35,10 +25,6 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
 
       - name: Install Node.js dependencies
         run: npm install
@@ -58,19 +44,3 @@ jobs:
             --gc \
             --minify \
             --baseURL "https://${{ env.CANONICAL_DOMAIN }}/"
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./public
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
With this PR, the [Deploy to GitHub Pages action](.github/workflows/deploy.yaml) is also executed within PRs targeting `main`. 

Publishing preview builds on GitHub pages from PRs is not officially supported. However, this would - at least - act as a build verification.