### PR TITLE
Update env variable naming convention in documentation

### DIFF
--- a/content/en/docs/spin-operator/tutorials/package-and-deploy.md
+++ b/content/en/docs/spin-operator/tutorials/package-and-deploy.md
@@ -130,7 +130,7 @@ For demonstration purposes, you will now distribute the Spin App via GitHub Cont
 
 ```shell
 # Store PAT and GitHub username as environment variables
-export CR_PAT=YOUR_TOKEN
+export GH_PAT=YOUR_TOKEN
 export GH_USER=YOUR_GITHUB_USERNAME
 
 # Authenticate spin CLI with GHCR


### PR DESCRIPTION
Updated documentation to reflect the change from exporting GitHub PAT as CR_PAT to GH_PAT for clarity and consistency