### PR TITLE
docs: reference to raw content for sample app

### DIFF
--- a/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
+++ b/content/en/docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service.md
@@ -152,7 +152,7 @@ To validate the Spin Operator deployment, you will deploy a simple Spin App to t
 
 ```shell
 # Deploy a sample Spin app
-kubectl apply -f https://github.com/spinkube/spin-operator/blob/main/config/samples/simple.yaml
+kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/samples/simple.yaml
 ```
 
 ## Verifying the Spin App


### PR DESCRIPTION
This PR contains a minor fix of the documentation for deploying SpinKube on a AKS cluster. The current description for applying the configuration of the sample app:

```bash
kubectl apply -f https://github.com/spinkube/spin-operator/blob/main/config/samples/simple.yaml
```

 leads to the following error:

```bash
error: error parsing https://github.com/spinkube/spin-operator/blob/main/config/samples/simple.yaml: error converting YAML to JSON: yaml: line 206: mapping values are not allowed in this context
```

The PR changes the statement to point to the raw content on GitHub which fixes the error from above
