### PR TITLE
Bump kube plugin version refs to 0.1.1

### DIFF
--- a/content/en/docs/spin-plugin-kube/contributing/_index.md
+++ b/content/en/docs/spin-plugin-kube/contributing/_index.md
@@ -40,7 +40,7 @@ spin plugins list --installed
 
 cloud 0.7.0 [installed]
 cloud-gpu 0.1.0 [installed]
-kube 0.1.0 [installed]
+kube 0.1.1 [installed]
 pluginify 0.6.0 [installed]
 ```
 

--- a/content/en/docs/spin-plugin-kube/installation/_index.md
+++ b/content/en/docs/spin-plugin-kube/installation/_index.md
@@ -41,7 +41,7 @@ spin plugins list --installed
 
 cloud 0.7.0 [installed]
 cloud-gpu 0.1.0 [installed]
-kube 0.1.0 [installed]
+kube 0.1.1 [installed]
 pluginify 0.6.0 [installed]
 ```
 


### PR DESCRIPTION
References to the `kube` plugin showed `0.1.0`. With this PR those references are updated to `0.1.1`