### PR TITLE
use `npm run generate:crd:reference` everywhere

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,6 @@ concurrency:
 
 env:
   CANONICAL_DOMAIN: www.spinkube.dev
-  SPIN_OPERATOR_RELEASE: v0.2.0
 
 jobs:
   # TODO: place into separate build.yaml (and add PR support?) and then call here?
@@ -55,10 +54,7 @@ jobs:
           cache: true
 
       - name: Generate CRD reference docs
-        run: ./generate.sh
-        working-directory: ./crd-reference
-        env:
-          SPIN_OPERATOR_RELEASE: ${{ env.SPIN_OPERATOR_RELEASE }}
+        run: npm run generate:crd:reference
 
       - name: Build
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  SPIN_OPERATOR_RELEASE: v0.2.0
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,10 +37,7 @@ jobs:
           cache: true
 
       - name: Generate CRD reference docs
-        run: ./generate.sh
-        working-directory: ./crd-reference
-        env:
-          SPIN_OPERATOR_RELEASE: ${{ env.SPIN_OPERATOR_RELEASE }}
+        run: npm run generate:crd:reference
 
       - name: Build
         run: |

--- a/crd-reference/.gitignore
+++ b/crd-reference/.gitignore
@@ -1,2 +1,0 @@
-spin-operator.crds.yaml
-spin-operator.crds.yaml.*

--- a/crd-reference/generate.sh
+++ b/crd-reference/generate.sh
@@ -1,33 +1,36 @@
 #! /bin/bash
 
-set -e 
+set -eo pipefail
 
-if [[ -z "$SPIN_OPERATOR_RELEASE" ]]; then
-    echo "Must provide SPIN_OPERATOR_RELEASE in environment" 1>&2
-    exit 1
-fi
+script_dir=$(dirname "$0")
+root_dir=$(dirname ${script_dir})
+
+cd $script_dir
+
+SPIN_OPERATOR_RELEASE=${SPIN_OPERATOR_RELEASE:-v0.2.0}
 
 echo "Installing crdoc"
 go install fybrik.io/crdoc@latest
 
-echo "Downloading Spin Operator CRDs ($SPIN_OPERATOR_RELEASE) "
-wget https://github.com/spinkube/spin-operator/releases/download/$SPIN_OPERATOR_RELEASE/spin-operator.crds.yaml
+echo "Downloading Spin Operator CRDs ($SPIN_OPERATOR_RELEASE)"
+spin_operator_crds_file=$(mktemp)
+wget https://github.com/spinkube/spin-operator/releases/download/$SPIN_OPERATOR_RELEASE/spin-operator.crds.yaml -O ${spin_operator_crds_file}
 
 # Generate SpinAppExecutor Reference Docs
 echo "Generating CRD reference docs for SpinAppExecutor"
-crdoc -r spin-operator.crds.yaml \
-    -o ../content/en/docs/spin-operator/reference/spin-app-executor.md \
+crdoc -r ${spin_operator_crds_file} \
+    -o ${root_dir}/content/en/docs/spin-operator/reference/spin-app-executor.md \
     --toc ./spin-app-executor-toc.yaml \
     --template ./spin-operator.tmpl
 
 echo "Generating CRD reference docs for SpinApp"
 # Generate SpinApp Reference Docs
-crdoc -r spin-operator.crds.yaml \
-    -o ../content/en/docs/spin-operator/reference/spin-app.md \
+crdoc -r ${spin_operator_crds_file} \
+    -o ${root_dir}/content/en/docs/spin-operator/reference/spin-app.md \
     --toc ./spin-app-toc.yaml \
     --template ./spin-operator.tmpl
 
-# Remove spin-operator.crds.yaml
-rm spin-operator.crds.yaml
+# Remove temporary file
+rm ${spin_operator_crds_file}
 
 echo "Done."

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run check:links",
     "update:pkg:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
     "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
-    "generate:crd:reference": "cd crd-reference && SPIN_OPERATOR_RELEASE=v0.2.0 ./generate.sh"
+    "generate:crd:reference": "./crd-reference/generate.sh"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",


### PR DESCRIPTION
This ensures that every time we generate the CRD reference docs, it runs in the same manner.

This also ensures that we only have to update SPIN_OPERATOR_RELEASE in one location rather than in four separate files.