### PR TITLE
fix: do not install hugo-extended in CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,16 +25,9 @@ jobs:
   # TODO: place into separate build.yaml (and add PR support?) and then call here?
   build:
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.123.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Setup Pages
         id: pages
@@ -62,7 +55,7 @@ jobs:
 
       - name: Build
         run: |
-          hugo \
+          npx hugo \
             --gc \
             --minify \
             --baseURL "https://${{ env.CANONICAL_DOMAIN }}/"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,16 +14,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.123.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - uses: actions/setup-node@v4
         with:
@@ -47,6 +40,6 @@ jobs:
 
       - name: Build
         run: |
-          hugo \
+          npx hugo \
             --gc \
             --minify


### PR DESCRIPTION
package.json declares which version of hugo is needed to build and run the project.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>