### PR TITLE
remove the logo_image from block / cover

### DIFF
--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -1,0 +1,54 @@
+{{ $_hugo_config := `{ "version": 1 }` -}}
+{{ $blockID := printf "td-cover-block-%d" .Ordinal -}}
+{{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**background*" -}}
+{{ $logo_image := (.Page.Resources.ByType "image").GetMatch "**logo*" -}}
+{{ $col_id := .Get "color" | default "dark" -}}
+{{ $image_anchor := .Get "image_anchor" | default "smart" -}}
+{{ $logo_anchor := .Get "logo_anchor" | default "smart" -}}
+{{/* Height can be one of: auto, min, med, max, full. */ -}}
+{{ $height := .Get "height" | default "max" -}}
+
+{{ with $promo_image -}}
+{{ $promo_image_big := . -}}
+{{ $promo_image_small := . -}}
+{{ if ne $promo_image.MediaType.SubType "svg" -}}
+  {{ $promo_image_big = .Fill (printf "1920x1080 %s" $image_anchor) -}}
+  {{ $promo_image_small = .Fill (printf "960x540 %s" $image_anchor) -}}
+{{ end -}}
+<link rel="preload" as="image" href="{{ $promo_image_small.RelPermalink }}" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
+<style>
+#{{ $blockID }} {
+  background-image: url({{ $promo_image_small.RelPermalink }});
+}
+@media only screen and (min-width: 1200px) {
+  #{{ $blockID }} {
+    background-image: url({{ $promo_image_big.RelPermalink }});
+  }
+}
+</style>
+{{ end -}}
+
+<section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height -}}
+  {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
+  {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
+  <div class="col-12">
+    <div class="container td-overlay__inner">
+      <div class="text-center">
+        {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ $title | html }}</h1>{{ end }}
+        {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
+        <div class="pt-3 lead">
+          {{ if eq .Page.File.Ext "md" }}
+              {{ .Inner | markdownify }}
+          {{ else }}
+              {{ .Inner | htmlUnescape | safeHTML }}
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+  {{ with .Get "byline" | default "" -}}
+    <div class="byline">{{ . }}</div>
+  {{- end }}
+</section>
+{{/**/ -}}


### PR DESCRIPTION
Removes a glitch where the Docsy template + shortcode for rendering the landing page is adding [an inline image](https://www.spinkube.dev/logo-fermyon_hu5d4a86a0bd2e04756375aecde81ca51b_3175_70x70_fit_catmullrom_3.png). 

This PR modifies the cover block partial template:
https://github.com/google/docsy/blob/main/layouts/shortcodes/blocks/cover.html#L38C9-L38C324

```
{{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
```

to remove the inline `{{ with $logo_image }}` part