### PR TITLE
fix "click to copy" not copying content

### DIFF
--- a/assets/js/click-to-copy.js
+++ b/assets/js/click-to-copy.js
@@ -1,5 +1,9 @@
 let codeListings = document.querySelectorAll('.highlight > pre');
 
+const copyCode = (codeSample) => {
+    navigator.clipboard.writeText(codeSample.textContent.trim() + '\n');
+};
+
 for (let index = 0; index < codeListings.length; index++) {
     const parentWrapper = codeListings[index].parentElement
     const plausibleClass = parentWrapper.dataset.plausible
@@ -30,7 +34,7 @@ for (let index = 0; index < codeListings.length; index++) {
 
     copyButton.onclick = () => {
         copyCode(codeSample);
-        copyButton.setAttribute('data-bs-original-title', 'Copied');
+        copyButton.setAttribute('data-bs-original-title', 'Copied!');
         tooltip.show();
     };
 
@@ -44,7 +48,3 @@ for (let index = 0; index < codeListings.length; index++) {
     buttonDiv.append(copyButton);
     codeListings[index].insertBefore(buttonDiv, codeSample);
 }
-
-const copyCode = (codeSample) => {
-    navigator.clipboard.writeText(codeSample.textContent.trim() + '\n');
-};

--- a/assets/js/click-to-copy.js
+++ b/assets/js/click-to-copy.js
@@ -27,9 +27,13 @@ for (let index = 0; index < codeListings.length; index++) {
         'btn',
         'btn-dark',
         'btn-sm',
-        'td-click-to-copy',
-        plausibleClass ? `plausible-event-name=${plausibleClass}` : ""
+        'td-click-to-copy'
     );
+
+    if (plausibleClass) {
+        copyButton.classList.add(`plausible-event-name=${plausibleClass}`);
+    }
+
     const tooltip = new bootstrap.Tooltip(copyButton);
 
     copyButton.onclick = () => {


### PR DESCRIPTION
Fixes `ReferenceError: Cannot access 'copyCode' before initialization`.

Also fixes the issue where "click to copy" was not being applied to the code block unless its parent had the `data-plausible` attribute applied.