### PR TITLE
Updated the curl command in the documentation to access the /hello endpint

### DIFF
--- a/content/en/docs/install/microk8s.md
+++ b/content/en/docs/install/microk8s.md
@@ -138,11 +138,11 @@ The easiest way to test our Spin app is to port forward from the Spin app to the
 $ microk8s kubectl port-forward services/simple-spinapp 8080:80
 ```
 
-You can then run `curl localhost:8080`
+You can then run `curl localhost:8080/hello`
 
 ```console { data-plausible="copy-quick-deploy-sample" }
-$ curl localhost:8080
-Hello World!
+$ curl localhost:8080/hello
+Hello world from Spin!
 ```
 
 ### Where to go from here


### PR DESCRIPTION
This pull request updates the curl command in the MicroK8s installation documentation to access the /hello endpoint instead of the root (localhost:8080).

### Changes
- Modified the curl command from `curl localhost:8080` to `curl localhost:8080/hello`.

### Reason for Change
- "curl localhost:8080" did not work.