### PR TITLE
chore: bump spin-operator chart version from 0.2.0 to 0.3.0

### DIFF
--- a/content/en/docs/install/azure-kubernetes-service.md
+++ b/content/en/docs/install/azure-kubernetes-service.md
@@ -148,7 +148,7 @@ namespace:
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.2.0 \
+  --version 0.3.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```

--- a/content/en/docs/install/installing-with-helm.md
+++ b/content/en/docs/install/installing-with-helm.md
@@ -91,7 +91,7 @@ The following installs the chart with the release name `spin-operator`:
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.2.0 \
+  --version 0.3.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```
@@ -111,7 +111,7 @@ To upgrade the `spin-operator` release, run the following:
 # Upgrade Spin Operator using Helm
 helm upgrade spin-operator \
   --namespace spin-operator \
-  --version 0.2.0 \
+  --version 0.3.0 \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator
 ```

--- a/content/en/docs/install/microk8s.md
+++ b/content/en/docs/install/microk8s.md
@@ -89,7 +89,7 @@ $ microk8s kubectl annotate node --all kwasm.sh/kwasm-node=true
 Next, we need to install SpinKube’s operator using Helm (which is included with Microk8s).
 
 ```console { data-plausible="copy-quick-deploy-sample" }
-$ microk8s helm install spin-operator --namespace spin-operator --create-namespace --version 0.2.0 --wait oci://ghcr.io/spinkube/charts/spin-operator
+$ microk8s helm install spin-operator --namespace spin-operator --create-namespace --version 0.3.0 --wait oci://ghcr.io/spinkube/charts/spin-operator
 
 ```
 


### PR DESCRIPTION
I've bumped install instructions from `0.2.0` to `0.3.0`. 