### PR TITLE
chore: bump documentation for shim v0.25.0 release

### DIFF
--- a/content/en/blog/community/spinkube-kind-rd/index.md
+++ b/content/en/blog/community/spinkube-kind-rd/index.md
@@ -12,7 +12,7 @@ resources:
 
 The goal of this guide is show a way to bring [SpinKube](https://www.spinkube.dev/) to
 [KinD](https://kind.sigs.k8s.io/) without the need of a custom image, like the [SpinKube on
-k3d](https://www.spinkube.dev/docs/spin-operator/quickstart/) example.
+KinD](https://www.spinkube.dev/docs/spin-operator/quickstart/) example.
 
 Instead, the Rancher Desktop (RD) Spin plugin will be used alongside KinD cluster configuration.
 

--- a/content/en/docs/contrib/troubleshooting.md
+++ b/content/en/docs/contrib/troubleshooting.md
@@ -115,12 +115,11 @@ FATA[0000] Failed to create cluster 'wasm-cluster' because a cluster with that n
 
 ### Cluster Information
 
-With `k3d` installed, you can use the following command to get a cluster list:
+With `kind` installed, you can use the following command to get a cluster list:
 
 ```console
-$ k3d cluster list
-NAME           SERVERS   AGENTS   LOADBALANCER
-wasm-cluster   1/1       2/2      true
+$ kind get clusters
+wasm-cluster
 ```
 
 With `kubectl installed, you can use the following command to dump cluster information (this is much
@@ -132,16 +131,10 @@ kubectl cluster-info dump
 
 ### Cluster Delete
 
-With `k3d` installed, you can delete the cluster by name, as shown in the command below:
+With `kind` installed, you can delete the cluster by name, as shown in the command below:
 
-```console
-$ k3d cluster delete wasm-cluster
-INFO[0000] Deleting cluster 'wasm-cluster'
-INFO[0002] Deleting cluster network 'k3d-wasm-cluster'
-INFO[0002] Deleting 1 attached volumes...
-INFO[0002] Removing cluster details from default kubeconfig...
-INFO[0002] Removing standalone kubeconfig file (if there is one)...
-INFO[0002] Successfully deleted cluster wasm-cluster!
+```sh
+kind delete cluster --name wasm-cluster
 ```
 
 ## Too long: must have at most 262144 bytes

--- a/content/en/docs/glossary.md
+++ b/content/en/docs/glossary.md
@@ -79,7 +79,7 @@ kind: SpinApp
 metadata:
   name: simple-spinapp
 spec:
-  image: "ghcr.io/spinframework/containerd-shim-spin/examples/spin-rust-hello:v0.24.0"
+  image: "ghcr.io/spinframework/containerd-shim-spin/examples/spin-rust-hello:v0.25.0"
   replicas: 1
   executor: "containerd-shim-spin"
 ```
@@ -96,7 +96,7 @@ kind: SpinApp
 metadata:
   name: simple-spinapp
 spec:
-  image: 'ghcr.io/spinframework/containerd-shim-spin/examples/spin-rust-hello:v0.24.0'
+  image: 'ghcr.io/spinframework/containerd-shim-spin/examples/spin-rust-hello:v0.25.0'
   replicas: 3
   imagePullSecrets:
     - name: spin-image-secret

--- a/content/en/docs/install/azure-kubernetes-service.md
+++ b/content/en/docs/install/azure-kubernetes-service.md
@@ -119,7 +119,7 @@ helm upgrade --install runtime-class-manager  \
   oci://ghcr.io/spinframework/charts/runtime-class-manager
 
 # Create Shim resource for installing the containerd-shim-spin binary
-kubectl apply -f https://raw.githubusercontent.com/spinframework/runtime-class-manager/refs/tags/v0.2.0/config/samples/sample_shim_spin.yaml
+kubectl apply -f https://github.com/spinframework/containerd-shim-spin/releases/download/v0.25.0/runtime-class-manager-shim-v1alpha1-v0.25.0.yaml
 
 # Label all Nodes where the shim should be installed (and thus where Spin Apps may run)
 # Note: this specific key and value matches the nodeSelector configuration used in the Shim resource above

--- a/content/en/docs/install/compatibility-matrices.md
+++ b/content/en/docs/install/compatibility-matrices.md
@@ -34,6 +34,8 @@ shim](https://github.com/spinframework/containerd-shim-spin) uses.
 
 | Shim Version  | Spin Version                                                       |
 |---------------|--------------------------------------------------------------------|
+| **Spin v4.x** |                                                                    |
+| *v0.25.0*     | [Spin v4.0.0](https://github.com/fermyon/spin/releases/tag/v4.0.0) |
 | **Spin v3.x** |                                                                    |
 | *v0.24.0*     | [Spin v3.6.3](https://github.com/fermyon/spin/releases/tag/v3.6.3) |
 | *v0.23.0*     | [Spin v3.6.2](https://github.com/fermyon/spin/releases/tag/v3.6.2) |

--- a/content/en/docs/install/installing-with-helm.md
+++ b/content/en/docs/install/installing-with-helm.md
@@ -43,7 +43,7 @@ helm upgrade --install runtime-class-manager  \
   oci://ghcr.io/spinframework/charts/runtime-class-manager
 
 # Create Shim resource for installing the containerd-shim-spin binary
-kubectl apply -f https://raw.githubusercontent.com/spinframework/runtime-class-manager/refs/tags/v0.2.0/config/samples/sample_shim_spin.yaml
+kubectl apply -f https://github.com/spinframework/containerd-shim-spin/releases/download/v0.25.0/runtime-class-manager-shim-v1alpha1-v0.25.0.yaml
 
 # Label all Nodes where the shim should be installed (and thus where Spin Apps may run)
 # Note: this specific key and value matches the nodeSelector configuration used in the Shim resource above

--- a/content/en/docs/install/microk8s.md
+++ b/content/en/docs/install/microk8s.md
@@ -84,7 +84,7 @@ microk8s helm upgrade --install runtime-class-manager  \
   oci://ghcr.io/spinframework/charts/runtime-class-manager
 
 # Create Shim resource for installing the containerd-shim-spin binary
-kubectl apply -f https://raw.githubusercontent.com/spinframework/runtime-class-manager/refs/tags/v0.2.0/config/samples/sample_shim_spin.yaml
+kubectl apply -f https://github.com/spinframework/containerd-shim-spin/releases/download/v0.25.0/runtime-class-manager-shim-v1alpha1-v0.25.0.yaml
 
 # Label all Nodes where the shim should be installed (and thus where Spin Apps may run)
 # Note: this specific key and value matches the nodeSelector configuration used in the Shim resource above

--- a/content/en/docs/install/quickstart.md
+++ b/content/en/docs/install/quickstart.md
@@ -17,7 +17,7 @@ For this Quickstart guide, you will need:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) - the Kubernetes CLI
 - A container runtime, such as [Docker
   Desktop](https://docs.docker.com/get-docker/), [Rancher Desktop](https://rancherdesktop.io/) or [OrbStack](https://orbstack.dev/)
-- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) - a a tool for running local development Kubernetes clusters using Docker container “nodes”.
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) - a tool for running local development Kubernetes clusters using Docker container “nodes”.
 - [Helm](https://helm.sh/docs/intro/install/) - the package manager for Kubernetes
 
 ### Set up Your Kubernetes Cluster

--- a/content/en/docs/install/quickstart.md
+++ b/content/en/docs/install/quickstart.md
@@ -1,43 +1,43 @@
 ---
 title: Quickstart
-description: Learn how to setup a Kubernetes cluser, install SpinKube and run your first Spin App.
+description: Learn how to setup a Kubernetes cluster, install SpinKube and run your first Spin App.
 weight: 2
 aliases:
   - /docs/quickstart
   - /docs/spin-operator/quickstart
 ---
 
-This Quickstart guide demonstrates how to set up a new Kubernetes cluster, install the SpinKube and
-deploy your first Spin application.
+This Quickstart guide demonstrates how to set up a development Kubernetes cluster, install SpinKube and
+deploy your first Spin application. This example creates a kind cluster with the Spin containerd shim pre-installed on all nodes. In production, you should use the runtime class manager to install and manage the lifecycle of the containerd shim. Jump to the [Helm installation](./installing-with-helm.md) for more production cluster installation instructions.
 
 ## Prerequisites
 
 For this Quickstart guide, you will need:
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) - the Kubernetes CLI
-- [Rancher Desktop](https://rancherdesktop.io/) or [Docker
-  Desktop](https://docs.docker.com/get-docker/) for managing containers and Kubernetes on your
-  desktop
-- [k3d](https://k3d.io/v5.6.0/?h=installation#installation) - a lightweight Kubernetes distribution
-  that runs on Docker
+- A container runtime, such as [Docker
+  Desktop](https://docs.docker.com/get-docker/), [Rancher Desktop](https://rancherdesktop.io/) or [OrbStack](https://orbstack.dev/)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) - a a tool for running local development Kubernetes clusters using Docker container “nodes”.
 - [Helm](https://helm.sh/docs/intro/install/) - the package manager for Kubernetes
 
 ### Set up Your Kubernetes Cluster
 
-1. Create a Kubernetes cluster with a k3d image that includes the
+1. Create a Kubernetes cluster with a kind image that includes the
    [containerd-shim-spin](https://github.com/spinframework/containerd-shim-spin) prerequisite already
-   installed:
+   installed. During creation of the kind cluster, we add containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class.:
 
-```console { data-plausible="copy-quick-create-k3d" }
-k3d cluster create wasm-cluster \
-  --image ghcr.io/spinframework/containerd-shim-spin/k3d:v0.24.0 \
-  --port "8081:80@loadbalancer" \
-  --agents 2
+```console { data-plausible="copy-quick-create-kind" }
+cat <<EOF | kind create cluster --name wasm-cluster --image ghcr.io/spinframework/containerd-shim-spin/kind:v0.25.0 --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin]
+    runtime_type = "io.containerd.spin.v2"
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin.options]
+    SystemdCgroup = true
+EOF
 ```
-
-> Note: Spin Operator requires a few Kubernetes resources that are installed globally to the
-> cluster. We create these directly through `kubectl` as a best practice, since their lifetimes are
-> usually managed separately from a given Spin Operator installation.
 
 2. Install cert-manager
 
@@ -51,14 +51,14 @@ kubectl wait --for=condition=available --timeout=300s deployment/cert-manager-we
    used for scheduling Spin apps onto nodes running the shim:
 
 > Note: In a production cluster you likely want to customize the Runtime Class with a `nodeSelector`
-> that matches nodes that have the shim installed. However, in the K3d example, they're installed on
+> that matches nodes that have the shim installed. However, in the kind example, the shim is pre-configured on
 > every node.
 
 ```console { data-plausible="copy-quick-apply-runtime-class" }
 kubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.runtime-class.yaml
 ```
 
-4. Apply the [Custom Resource Definitions]({{< ref "glossary#custom-resource-definition-crd" >}})
+1. Apply the [Custom Resource Definitions]({{< ref "glossary#custom-resource-definition-crd" >}})
    used by the Spin Operator:
 
 ```console { data-plausible="copy-quick-apply-crd" }
@@ -67,7 +67,7 @@ kubectl apply -f https://github.com/spinframework/spin-operator/releases/downloa
 
 ## Deploy the Spin Operator
 
-Execute the following command to install the Spin Operator on the K3d cluster using Helm. This will
+Execute the following command to install the Spin Operator on the cluster using Helm. This will
 create all of the Kubernetes resources required by Spin Operator under the Kubernetes namespace
 `spin-operator`. It may take a moment for the installation to complete as dependencies are installed
 and pods are spinning up.

--- a/content/en/docs/misc/compatibility.md
+++ b/content/en/docs/misc/compatibility.md
@@ -16,6 +16,7 @@ Operator](https://github.com/spinframework/spin-operator/):
  - [Digital Ocean Kubernetes (DOKS)](https://www.digitalocean.com/products/kubernetes)
  - [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
  - [k3d](https://k3d.io)
+ - [kind](https://kind.sigs.k8s.io/)
  - [minikube](https://minikube.sigs.k8s.io/docs/) (explicitly pass `--container-runtime=containerd`
    and ensure you're on minikube version `>= 1.33`)
  - [Scaleway Kubernetes Kapsule](https://www.scaleway.com/en/kubernetes-kapsule/)

--- a/content/en/docs/topics/autoscaling/scaling-with-hpa.md
+++ b/content/en/docs/topics/autoscaling/scaling-with-hpa.md
@@ -32,7 +32,7 @@ Ensure you have the following tools installed:
 
 Run the following command to create a Kubernetes cluster that has [the
 containerd-shim-spin](https://github.com/spinframework/containerd-shim-spin) pre-requisites installed: If
-you have a Kubernetes cluster already, or want to start with a more production ready SpinKube installation, follow the [Helm installation guide](../install/installing-with-helm.md) instead, which include instructions for configuring the Runtime Class Manager for managing the lifecycle of the Spin containerd shim. The following `kind` cluster creation creates a three node cluster with containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class. We are also exposing host port 8081 to make load testing easier in later steps.
+you have a Kubernetes cluster already, or want to start with a more production ready SpinKube installation, follow the [Helm installation guide](../../install/installing-with-helm.md) instead, which include instructions for configuring the Runtime Class Manager for managing the lifecycle of the Spin containerd shim. The following `kind` cluster creation creates a three node cluster with containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class. We are also exposing host port 8081 to make load testing easier in later steps.
 
 ```console
 cat <<EOF | kind create cluster --name wasm-cluster-scale --image ghcr.io/spinframework/containerd-shim-spin/kind:v0.25.0 --config=-

--- a/content/en/docs/topics/autoscaling/scaling-with-hpa.md
+++ b/content/en/docs/topics/autoscaling/scaling-with-hpa.md
@@ -18,27 +18,41 @@ scale the instance count of our SpinApps to meet the demand.
 
 Ensure you have the following tools installed:
 
-- [Docker](https://docs.docker.com/engine/install/) - for running k3d
+- [Docker](https://docs.docker.com/engine/install/) - for running kind
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) - the Kubernetes CLI
-- [k3d](https://k3d.io) - a lightweight Kubernetes distribution that runs on Docker
+- [kind](https://kind.sigs.k8s.io/) - a development Kubernetes distribution that runs on Docker
 - [Helm](https://helm.sh) - the package manager for Kubernetes
 - [Bombardier](https://pkg.go.dev/github.com/codesenberg/bombardier) - cross-platform HTTP
   benchmarking CLI
 
-> We use k3d to run a Kubernetes cluster locally as part of this tutorial, but you can follow these
+> We use kind to run a Kubernetes cluster locally as part of this tutorial, but you can follow these
 > steps to configure HPA autoscaling on your desired Kubernetes environment.
 
 ## Setting Up Kubernetes Cluster
 
 Run the following command to create a Kubernetes cluster that has [the
 containerd-shim-spin](https://github.com/spinframework/containerd-shim-spin) pre-requisites installed: If
-you have a Kubernetes cluster already, please feel free to use it:
+you have a Kubernetes cluster already, or want to start with a more production ready SpinKube installation, follow the [Helm installation guide](../install/installing-with-helm.md) instead, which include instructions for configuring the Runtime Class Manager for managing the lifecycle of the Spin containerd shim. The following `kind` cluster creation creates a three node cluster with containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class. We are also exposing host port 8081 to make load testing easier in later steps.
 
 ```console
-k3d cluster create wasm-cluster-scale \
-  --image ghcr.io/spinframework/containerd-shim-spin/k3d:v0.24.0 \
-  -p "8081:80@loadbalancer" \
-  --agents 2
+cat <<EOF | kind create cluster --name wasm-cluster-scale --image ghcr.io/spinframework/containerd-shim-spin/kind:v0.25.0 --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin]
+    runtime_type = "io.containerd.spin.v2"
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin.options]
+    SystemdCgroup = true
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8081
+    protocol: TCP
+- role: worker
+- role: worker
+EOF
 ```
 
 ### Deploying Spin Operator and its dependencies
@@ -69,7 +83,7 @@ Next, run the following commands to install the Spin [Runtime Class]({{<ref
 "glossary#custom-resource-definition-crd">}}):
 
 > Note: In a production cluster you likely want to customize the Runtime Class with a `nodeSelector`
-> that matches nodes that have the shim installed. However, in the K3d example, they're installed on
+> that matches nodes that have the shim installed. However, in the kind example, they're installed on
 > every node.
 
 ```console
@@ -99,13 +113,31 @@ kubectl apply -f https://github.com/spinframework/spin-operator/releases/downloa
 Great, now you have Spin Operator up and running on your cluster. This means you’re set to create
 and deploy SpinApps later on in the tutorial.
 
-## Set Up Ingress
+## Install an Ingress Controller
+
+Install an ingress controller in your cluster. This example uses Traefik as the ingress controller for local routing in Kind. We are requiring that it is run on the control-plane node where the hostPort is exposed.
+
+```sh
+helm repo add traefik https://helm.traefik.io/traefik
+helm repo update
+helm install traefik traefik/traefik \
+  --namespace traefik --create-namespace \
+  --set deployment.kind=DaemonSet \
+  --set service.type=ClusterIP \
+  --set ports.web.hostPort=80 \
+  --set tolerations[0].key=node-role.kubernetes.io/control-plane \
+  --set tolerations[0].effect=NoSchedule \
+  --set tolerations[0].operator=Exists \
+  --set nodeSelector."kubernetes\.io/hostname"=wasm-cluster-scale-control-plane
+kubectl wait --namespace traefik --for=condition=ready pod --selector=app.kubernetes.io/name=traefik --timeout=180s
+```
+
+## Set Up Ingress for the Spin App
 
 Use the following command to set up ingress on your Kubernetes cluster. This ensures traffic can
-reach your SpinApp once we’ve created it in future steps:
+reach your Spin app once we’ve created it in future steps:
 
 ```console
-# Setup ingress following this tutorial https://k3d.io/v5.4.6/usage/exposing_services/
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -114,6 +146,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: traefik
   rules:
   - http:
       paths:
@@ -126,8 +159,6 @@ spec:
               number: 80
 EOF
 ```
-
-Hit enter to create the ingress resource.
 
 ## Deploy Spin App and HorizontalPodAutoscaler (HPA)
 

--- a/content/en/docs/topics/autoscaling/scaling-with-keda.md
+++ b/content/en/docs/topics/autoscaling/scaling-with-keda.md
@@ -20,25 +20,39 @@ Please ensure the following tools are installed on your local machine:
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) - the Kubernetes CLI
 - [Helm](https://helm.sh) - the package manager for Kubernetes
-- [Docker](https://docs.docker.com/engine/install/) - for running k3d
-- [k3d](https://k3d.io) - a lightweight Kubernetes distribution that runs on Docker
+- [Docker](https://docs.docker.com/engine/install/) - for running kind
+- [kind](https://kind.sigs.k8s.io/) - a development Kubernetes distribution that runs on Docker
 - [Bombardier](https://pkg.go.dev/github.com/codesenberg/bombardier) - cross-platform HTTP
   benchmarking CLI
 
-> We use k3d to run a Kubernetes cluster locally as part of this tutorial, but you can follow these
+> We use kind to run a Kubernetes cluster locally as part of this tutorial, but you can follow these
 > steps to configure KEDA autoscaling on your desired Kubernetes environment.
 
 ## Setting Up Kubernetes Cluster
 
 Run the following command to create a Kubernetes cluster that has [the
 containerd-shim-spin](https://github.com/spinframework/containerd-shim-spin) pre-requisites installed: If
-you have a Kubernetes cluster already, please feel free to use it:
+you have a Kubernetes cluster already, or want to start with a more production ready SpinKube installation, follow the [Helm installation guide](../install/installing-with-helm.md) instead, which include instructions for configuring the Runtime Class Manager for managing the lifecycle of the Spin containerd shim. The following `kind` cluster creation creates a three node cluster with containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class. We are also exposing host port 8081 to make load testing easier in later steps.
 
 ```console
-k3d cluster create wasm-cluster-scale \
-  --image ghcr.io/spinframework/containerd-shim-spin/k3d:v0.24.0 \
-  -p "8081:80@loadbalancer" \
-  --agents 2
+cat <<EOF | kind create cluster --name wasm-cluster-scale --image ghcr.io/spinframework/containerd-shim-spin/kind:v0.25.0 --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin]
+    runtime_type = "io.containerd.spin.v2"
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin.options]
+    SystemdCgroup = true
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8081
+    protocol: TCP
+- role: worker
+- role: worker
+EOF
 ```
 
 ### Deploying Spin Operator and its dependencies
@@ -69,7 +83,7 @@ Next, run the following commands to install the Spin [Runtime Class]({{<ref
 "glossary#custom-resource-definition-crd">}}):
 
 > Note: In a production cluster you likely want to customize the Runtime Class with a `nodeSelector`
-> that matches nodes that have the shim installed. However, in the K3d example, they're installed on
+> that matches nodes that have the shim installed. However, in the kind example, they're installed on
 > every node.
 
 ```console
@@ -99,13 +113,31 @@ kubectl apply -f https://github.com/spinframework/spin-operator/releases/downloa
 Great, now you have Spin Operator up and running on your cluster. This means you’re set to create
 and deploy SpinApps later on in the tutorial.
 
-## Set Up Ingress
+## Install an Ingress Controller
+
+Install an ingress controller in your cluster. This example uses Traefik as the ingress controller for local routing in Kind. We are requiring that it is run on the control-plane node where the hostPort is exposed.
+
+```sh
+helm repo add traefik https://helm.traefik.io/traefik
+helm repo update
+helm install traefik traefik/traefik \
+  --namespace traefik --create-namespace \
+  --set deployment.kind=DaemonSet \
+  --set service.type=ClusterIP \
+  --set ports.web.hostPort=80 \
+  --set tolerations[0].key=node-role.kubernetes.io/control-plane \
+  --set tolerations[0].effect=NoSchedule \
+  --set tolerations[0].operator=Exists \
+  --set nodeSelector."kubernetes\.io/hostname"=wasm-cluster-scale-control-plane
+kubectl wait --namespace traefik --for=condition=ready pod --selector=app.kubernetes.io/name=traefik --timeout=180s
+```
+
+## Set Up Ingress for the Spin App
 
 Use the following command to set up ingress on your Kubernetes cluster. This ensures traffic can
 reach your Spin App once we’ve created it in future steps:
 
 ```console
-# Setup ingress following this tutorial https://k3d.io/v5.4.6/usage/exposing_services/
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -114,6 +146,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: traefik
   rules:
   - http:
       paths:
@@ -126,8 +159,6 @@ spec:
               number: 80
 EOF
 ```
-
-Hit enter to create the ingress resource.
 
 ## Setting Up KEDA
 

--- a/content/en/docs/topics/autoscaling/scaling-with-keda.md
+++ b/content/en/docs/topics/autoscaling/scaling-with-keda.md
@@ -32,7 +32,7 @@ Please ensure the following tools are installed on your local machine:
 
 Run the following command to create a Kubernetes cluster that has [the
 containerd-shim-spin](https://github.com/spinframework/containerd-shim-spin) pre-requisites installed: If
-you have a Kubernetes cluster already, or want to start with a more production ready SpinKube installation, follow the [Helm installation guide](../install/installing-with-helm.md) instead, which include instructions for configuring the Runtime Class Manager for managing the lifecycle of the Spin containerd shim. The following `kind` cluster creation creates a three node cluster with containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class. We are also exposing host port 8081 to make load testing easier in later steps.
+you have a Kubernetes cluster already, or want to start with a more production ready SpinKube installation, follow the [Helm installation guide](../../install/installing-with-helm.md) instead, which include instructions for configuring the Runtime Class Manager for managing the lifecycle of the Spin containerd shim. The following `kind` cluster creation creates a three node cluster with containerd configuration to instruct containerd to use the Spin containerd shim for workloads scheduled with the `spin` runtime class. We are also exposing host port 8081 to make load testing easier in later steps.
 
 ```console
 cat <<EOF | kind create cluster --name wasm-cluster-scale --image ghcr.io/spinframework/containerd-shim-spin/kind:v0.25.0 --config=-


### PR DESCRIPTION
Transitions from using k3d to using kind for the Quickstart example. Emphasizes that the runtime class manager should be used in production clusters.

~DRAFT: v0.25.0 is not released yet. staging this to show the kind changes and discuss how we should update RCM based installations to pull in the new shim. Currently, we point to the RCM v0.2.0 Shim artifact which pulls in v0.23.0 of the shim:~
